### PR TITLE
Implement auto-updater.

### DIFF
--- a/.github/auto-updated/index.js
+++ b/.github/auto-updated/index.js
@@ -1,0 +1,27 @@
+const { Toolkit } = require("actions-toolkit");
+const fetch = require("node-fetch");
+
+Toolkit.run(
+  async (tools) => {
+    const res = await fetch(`http://api.phish.surf:5000/gimme-domains`, {
+      headers: { "User-Agent": "Anti-Scam Database GitHub Action" }
+    });
+    if (res.status !== 200) return tools.exit.failure(`Could not retrieve latest domains from api.phish.surf:5000/gimme-domains. Site responded with ${res.status}`);
+    
+    
+    const template = await tools.readFile("./template.md");
+    const { pull_request } = tools.context.payload;
+    //tools.log.debug(pull_request);
+    const file = require(__dirname + "/../../database/summary.json");
+    let text = [];
+    file.forEach((data) => {
+      text.push(`• ${data.domain}`);
+    });
+    text = text.join("\n");
+    tools.exit.success("Successfully updated Database!");
+  },
+  {
+    event: ["schedule"],
+    secrets: ["GITHUB_TOKEN"],
+  }
+);


### PR DESCRIPTION
## The Goal
This PR will implement a automatic GitHub Action.

The Action would run once a day to connect to http://api.phish.surf:5000/gimme-domains, get the JSON array it returns and compare the list to its own JSON files and the `summary.json`
If it finds new domains that aren't yet stored here would it do two things:

1. Create new JSON files with the name-pattern used right now (`<domain>.<tld>-<day>.<month>.json`) in the corresponding year folder and have them contain the following JSON info.
   ```json
   {
     "domain": "<domain>.<tld>",
     "affected_platforms": []
   }
   ```
2. Add the same info into the `summary.json`

The biggest issues I so far see is to find a way of comparing the different formats with each other and to not make pointless commits when no changes are present...